### PR TITLE
Add Vagrantfile for testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ work/
 .project
 *.iml
 .DS_Store
+.vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,7 +3,7 @@
 Vagrant.configure(2) do |config|
 
   config.vm.box = "ubuntu/trusty64"
-  config.vm.network "public_network", bridge: "en0: Wi-Fi (AirPort)"
+  config.vm.network "private_network", ip: "10.11.12.100"
   config.vm.provider "virtualbox" do |vb|
     vb.memory = "1024"
   end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,8 +13,30 @@ Vagrant.configure(2) do |config|
     sudo sh -c 'echo deb http://pkg.jenkins-ci.org/debian binary/ > /etc/apt/sources.list.d/jenkins.list'
     sudo apt-get update
     sudo apt-get install openjdk-7-jdk jenkins maven -y
+
+    # Run Jenkins as the vagrant user
     sudo sed -i 's/^JENKINS_USER.*/JENKINS_USER=vagrant/;s/^JENKINS_GROUP.*/JENKINS_GROUP=vagrant/' /etc/default/jenkins
+    sudo chown -R vagrant.vagrant /var/cache/jenkins /var/lib/jenkins /var/log/jenkins
+
+    # configure settings.xml as mentioned in the prerequisites
+    cat <<EOF > ~/.m2/settings.xml
+<settings>
+  <profiles>
+    <profile>
+      <id>compiler</id>
+        <properties>
+          <JAVA_1_7_HOME>/usr/lib/jvm/java-7-openjdk-amd64</JAVA_1_7_HOME>
+        </properties>
+    </profile>
+  </profiles>
+  <activeProfiles>
+    <activeProfile>compiler</activeProfile>
+  </activeProfiles>
+</settings>
+EOF
+
     sudo service jenkins restart
     sudo update-rc.d jenkins enable
   SHELL
 end
+

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -39,8 +39,9 @@ EOF
     # Set HUDSON_HOME for maven builds
     echo 'export HUDSON_HOME=/var/lib/jenkins' > ~/.profile
 
-    sudo service jenkins restart
-    sudo update-rc.d jenkins enable
+    # Stop the jenkins service so that hpi:run doesn't complain about 8080 port
+    sudo service jenkins stop
+    sudo update-rc.d jenkins disable
   SHELL
 end
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,7 +13,8 @@ Vagrant.configure(2) do |config|
     sudo sh -c 'echo deb http://pkg.jenkins-ci.org/debian binary/ > /etc/apt/sources.list.d/jenkins.list'
     sudo apt-get update
     sudo apt-get install openjdk-7-jdk jenkins maven -y
-    sudo service jenkins start
+    sudo sed -i 's/^JENKINS_USER.*/JENKINS_USER=vagrant/;s/^JENKINS_GROUP.*/JENKINS_GROUP=vagrant/' /etc/default/jenkins
+    sudo service jenkins restart
     sudo update-rc.d jenkins enable
   SHELL
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,7 +8,7 @@ Vagrant.configure(2) do |config|
     vb.memory = "1024"
   end
 
-  config.vm.provision "shell", inline: <<-SHELL
+  config.vm.provision "shell", privileged: false, inline: <<-SHELL
     wget -q -O - https://jenkins-ci.org/debian/jenkins-ci.org.key | sudo apt-key add -
     sudo sh -c 'echo deb http://pkg.jenkins-ci.org/debian binary/ > /etc/apt/sources.list.d/jenkins.list'
     sudo apt-get update
@@ -19,6 +19,7 @@ Vagrant.configure(2) do |config|
     sudo chown -R vagrant.vagrant /var/cache/jenkins /var/lib/jenkins /var/log/jenkins
 
     # configure settings.xml as mentioned in the prerequisites
+    mkdir ~/.m2 > /dev/null 2>&1
     cat <<EOF > ~/.m2/settings.xml
 <settings>
   <profiles>
@@ -34,6 +35,9 @@ Vagrant.configure(2) do |config|
   </activeProfiles>
 </settings>
 EOF
+
+    # Set HUDSON_HOME for maven builds
+    echo 'export HUDSON_HOME=/var/lib/jenkins' > ~/.profile
 
     sudo service jenkins restart
     sudo update-rc.d jenkins enable

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,19 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+Vagrant.configure(2) do |config|
+
+  config.vm.box = "ubuntu/trusty64"
+  config.vm.network "public_network", bridge: "en0: Wi-Fi (AirPort)"
+  config.vm.provider "virtualbox" do |vb|
+    vb.memory = "1024"
+  end
+
+  config.vm.provision "shell", inline: <<-SHELL
+    wget -q -O - https://jenkins-ci.org/debian/jenkins-ci.org.key | sudo apt-key add -
+    sudo sh -c 'echo deb http://pkg.jenkins-ci.org/debian binary/ > /etc/apt/sources.list.d/jenkins.list'
+    sudo apt-get update
+    sudo apt-get install openjdk-7-jdk jenkins maven -y
+    sudo service jenkins start
+    sudo update-rc.d jenkins enable
+  SHELL
+end


### PR DESCRIPTION
Added a simple Vagrantfile (based on Ubuntu 14.04) to help with testing, takes care of the following:
- Adds Jenkins APT repos and installs the latest version.
- Install plugin development related tools (JDK, Maven).
- Starts the jenkins services and enables it on boot.
